### PR TITLE
Turning off Arbitrary Loads and whitelisting IP

### DIFF
--- a/Lumpen Radio/Info.plist
+++ b/Lumpen Radio/Info.plist
@@ -23,7 +23,17 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<true/>
+		<false/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>mensajito.mx</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
+		</dict>
 	</dict>
 	<key>UIAppFonts</key>
 	<array>


### PR DESCRIPTION
Fixed plist to disallow arbitrary loads and whitelisted audio source domain