### PR TITLE
Updated the radio endpoint URL

### DIFF
--- a/Lumpen Radio.xcodeproj/project.pbxproj
+++ b/Lumpen Radio.xcodeproj/project.pbxproj
@@ -517,7 +517,7 @@
 				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.publicmediainstitute.lumpenradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Lumpen Radio iOS Dist";
+				PROVISIONING_PROFILE_SPECIFIER = "Lumpen iOS Distribution Provision";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -542,7 +542,7 @@
 				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.publicmediainstitute.lumpenradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Lumpen Radio iOS Dist";
+				PROVISIONING_PROFILE_SPECIFIER = "Lumpen iOS Distribution Provision";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/Lumpen Radio.xcodeproj/project.pbxproj
+++ b/Lumpen Radio.xcodeproj/project.pbxproj
@@ -504,7 +504,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"Lumpen Radio/Preview Content\"";
 				DEVELOPMENT_TEAM = 3FGY239S7X;
 				ENABLE_PREVIEWS = YES;
@@ -514,7 +514,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.publicmediainstitute.lumpenradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Lumpen Radio iOS Dist";
@@ -529,7 +529,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"Lumpen Radio/Preview Content\"";
 				DEVELOPMENT_TEAM = 3FGY239S7X;
 				ENABLE_PREVIEWS = YES;
@@ -539,7 +539,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.publicmediainstitute.lumpenradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Lumpen Radio iOS Dist";

--- a/Lumpen Radio/Radio.swift
+++ b/Lumpen Radio/Radio.swift
@@ -11,7 +11,7 @@ import AVFoundation
 import MediaPlayer
 
 // Constants
-fileprivate let LUMPEN_AUDIO_URL: String = "http://mensajito.mx:8000/lumpen"
+fileprivate let LUMPEN_AUDIO_URL: String = "https://radio.mensajito.mx/lumpenradio"
 fileprivate let NOW_PLAYING_TITLE = "Lumpen Radio"
 fileprivate let NOW_PLAYING_ALBUM_TITLE = "WLPN 105.5 FM Chicago"
 fileprivate let NOW_PLAYING_ARTWORK_IMG = "AppIcon"


### PR DESCRIPTION
## Summary
The endpoint for the radio stream changed

## Change list
- Version number bumped to 1.1.0, build number 5
- Updated endpoint: `"http://mensajito.mx:8000/lumpen"` -> `"https://radio.mensajito.mx/lumpenradio"`